### PR TITLE
fix js error if js-filename includes '-'

### DIFF
--- a/lib/sprockets/babel.rb
+++ b/lib/sprockets/babel.rb
@@ -128,7 +128,7 @@ module Sprockets
     end
 
     def self.escape_module_id(module_id)
-      '$__' + ERB::Util.url_encode(module_id.gsub(/^\.\//, '')).gsub(/%/, '') + '__'
+      '$__' + ERB::Util.url_encode(module_id.gsub(/^\.\//, '')).gsub(/%|-/, '') + '__'
     end
   end
 


### PR DESCRIPTION
javascript cannot use '-' for variable,
if filename is "foo-bar.js", maybe an error occurs ("Unexpected token -"), right?

by now, i guess you get used to my funny English writing.
